### PR TITLE
Add Go 1.22 study notes and runnable examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+.vscode/
+*.out
+bin/
+dist/

--- a/1-Pacotes/go.mod
+++ b/1-Pacotes/go.mod
@@ -1,5 +1,5 @@
 module auxiliar
 
-go 1.17
+go 1.22
 
 require github.com/badoux/checkmail v1.2.1 // indirect

--- a/16-AplicacaoLinhaDeComando/go.mod
+++ b/16-AplicacaoLinhaDeComando/go.mod
@@ -1,6 +1,6 @@
 module linha-de-comando
 
-go 1.17
+go 1.22
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect

--- a/19-Testes/1-introducao/go.mod
+++ b/19-Testes/1-introducao/go.mod
@@ -1,3 +1,3 @@
 module introducao-testes
 
-go 1.17
+go 1.22

--- a/20-Go1.22-Novidades/README.md
+++ b/20-Go1.22-Novidades/README.md
@@ -1,0 +1,29 @@
+# Novidades do Go 1.22
+
+Este diretório reúne exemplos de estudo das mudanças introduzidas no Go 1.22.
+
+## Range sobre inteiros
+
+O `range` pode iterar diretamente sobre um inteiro, iniciando em `0` e indo até `n-1`.
+
+```go
+for i := range 5 {
+	fmt.Println(i)
+}
+```
+
+## Variáveis de range por iteração
+
+As variáveis do `range` passam a ser recriadas a cada iteração, o que evita capturas
+incorretas em closures quando usamos goroutines.
+
+```go
+for i := range 3 {
+	go func() {
+		fmt.Println(i)
+	}()
+}
+```
+
+> Observação: a ordem de impressão não é garantida por causa da concorrência,
+> mas cada goroutine imprime o valor correto de `i`.

--- a/20-Go1.22-Novidades/main.go
+++ b/20-Go1.22-Novidades/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+func main() {
+	fmt.Println("Range sobre inteiros:")
+	for i := range 5 {
+		fmt.Println("i:", i)
+	}
+
+	fmt.Println("\nVariáveis de range por iteração:")
+	var wg sync.WaitGroup
+	for i := range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fmt.Println("goroutine:", i)
+		}()
+	}
+	wg.Wait()
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,46 @@
   go mod init name_module
 ```
 
+### Estrutura do projeto
+- Cada pasta numerada representa um tema de estudo com exemplos autocontidos.
+- Os exemplos que possuem dependências externas possuem seu próprio `go.mod`.
+- Use o workspace (`go.work`) na raiz para navegar entre módulos com facilidade.
+
+```sh
+  # baixa dependências e mantém o workspace sincronizado
+  go work sync
+
+  # executa um exemplo específico
+  go run ./4-Funcoes
+```
+
+### Mapa de estudos
+- 1-Pacotes: organização de pacotes e módulos.
+- 2-Variaveis: variáveis e tipos básicos.
+- 3-TiposDeDados: tipos primitivos e conversões.
+- 4-Funcoes: funções e padrões comuns.
+- 5-Structs: structs e composição básica.
+- 6-Pseudo-Heranca-Composicao: composição e embedding.
+- 7-Ponteiros: ponteiros e passagem por referência.
+- 8-Array-Slice: arrays, slices e matrizes.
+- 9-Maps: mapas e operações.
+- 10-Estruturas-De-Controle: if/else e controle de fluxo.
+- 11-Switch: uso de switch.
+- 12-Loops: laços for.
+- 13-Funcoes Avancadas: defer, closures, init e panic/recover.
+- 14-Metodos: métodos em structs e interfaces básicas.
+- 15-Interfaces: interfaces e exemplos genéricos.
+- 16-AplicacaoLinhaDeComando: app CLI com dependências externas.
+- 17-Concorrencia: goroutines, channels e wait groups.
+- 18-ConcurrencyPatterns: padrões de concorrência.
+- 19-Testes: exemplos de testes e estrutura de pacotes.
+- 20-Go1.22-Novidades: estudos sobre novidades do Go 1.22.
+
+### Novidades do Go 1.22
+- `for range` sobre inteiros (ex.: `for i := range 5`) para iterações simples.
+- Variáveis de `range` passam a ser recriadas por iteração, evitando capturas erradas em closures.
+- Confira exemplos na pasta `20-Go1.22-Novidades`.
+
 ### Functions
 
 - Function com a primeira letra minuscula significa que ela eh visivel somente dentro do pacote, ou um convencao de ser um metodo privado do pacote pertencente.

--- a/go.work
+++ b/go.work
@@ -1,0 +1,7 @@
+go 1.22
+
+use (
+	./1-Pacotes
+	./16-AplicacaoLinhaDeComando
+	./19-Testes/1-introducao
+)


### PR DESCRIPTION
### Motivation
- Document the repository with a clear study map and capture new language behaviors introduced in Go 1.22 to support learning and examples. 
- Provide a small, runnable set of examples that illustrate the new `range` behaviors so students can experiment and verify the changes themselves.

### Description
- Update `README.md` to include a study map and a `Novidades do Go 1.22` section that highlights new language features. 
- Add `20-Go1.22-Novidades/README.md` with explanations and code snippets demonstrating `for i := range N` and per-iteration `range` variable semantics. 
- Add `20-Go1.22-Novidades/main.go` as a runnable example that prints integer-range iterations and demonstrates that `range` variables are recreated per iteration when used with goroutines and a `sync.WaitGroup`.

### Testing
- No automated tests were run (`go test` was not executed). 
- No runtime verification was performed (`go run` was not executed) for the new example in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983697888f88321b12fcbf469fb2e55)